### PR TITLE
Improve SNMPAT community string input and scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ SNMPAT (SNMP Auditing Tool) is a project that provides a set of tools for SNMP (
 - It allows you to perform SNMP GET, GETNEXT, GETBULK, and SET operations.
 - SNMPAT provides a command-line interface for easy integration into scripts and automation workflows.
 - It supports both IPv4 and IPv6 addresses for SNMP communication.
+- The scanner lets you supply custom SNMP community strings or use a built-in default list.
 
 ## Usage
 
-> ./snmpat.sh
+Run the script and follow the prompts to enter target subnets/IPs and SNMP community strings:
+
+```bash
+./snmpat.sh
+```
 
 ## Dependencies
 SNMPAT has the following dependencies:


### PR DESCRIPTION
## Summary
- allow users to supply custom SNMP community strings or use defaults
- fix progress display and reuse a single community string list for scanning
- document new community string options in README

## Testing
- `bash -n SNMPAT.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895463d1308832a9defd05fb2512ec6