### PR TITLE
Improve SNMP target handling and add smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,31 @@ SNMPAT (SNMP Auditing Tool) is a project that provides a set of tools for SNMP (
 - It allows you to perform SNMP GET, GETNEXT, GETBULK, and SET operations.
 - SNMPAT provides a command-line interface for easy integration into scripts and automation workflows.
 - It supports both IPv4 and IPv6 addresses for SNMP communication.
+- The scanner lets you supply custom SNMP community strings or use a built-in default list.
 
 ## Usage
 
-> ./snmpat.sh
+Run the script and follow the prompts to enter target subnets/IPs and SNMP community strings:
+
+```bash
+./SNMPAT.sh
+```
+
+During execution you can build the SNMP community string list by combining any of the following sources:
+
+- Add the built-in defaults with one menu selection.
+- Enter additional strings directly (comma or space separated); duplicate and blank values are ignored automatically.
+- Load strings from a text or CSV file, where values can be separated by commas or whitespace across multiple lines.
+
+You can review the growing list after each addition and only proceed once you are satisfied, ensuring the scan always runs with a clean, deduplicated set of community strings.
+
+### Testing
+
+The repository includes a lightweight smoke test that exercises the interactive prompts with mocked `onesixtyone` and `dig` binaries. Run it from the project root with:
+
+```bash
+tests/run_tests.sh
+```
 
 ## Dependencies
 SNMPAT has the following dependencies:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ During execution you can build the SNMP community string list by combining any o
 
 You can review the growing list after each addition and only proceed once you are satisfied, ensuring the scan always runs with a clean, deduplicated set of community strings.
 
+When you are ready to supply targets, enter subnets, IPs, or file paths in any order. Use the `done` keyword to review a summary of
+the current selections; the script highlights any IPs already covered by one of the subnets so you know exactly what will be scanned
+before the tool continues.
+
 ### Testing
 
 The repository includes a lightweight smoke test that exercises the interactive prompts with mocked `onesixtyone` and `dig` binaries. Run it from the project root with:

--- a/SNMPAT.sh
+++ b/SNMPAT.sh
@@ -19,17 +19,128 @@ check_dependencies() {
 
 check_dependencies
 
+# Prompt user for SNMP community strings and store them in a temporary file
+get_community_strings() {
+    local default_strings=("public" "community" "default" "admin" "private" "manager" "cisco" "snmp" "network" "monitor" "agent" "trap" "read" "write")
+    local -a collected_strings=()
+    declare -A seen_strings=()
+    local choice cs_input cs_file line entry trimmed
+
+    while true; do
+        echo -e "\e[93mSelect how to build the community string list:\e[0m"
+        echo "1. Add default list"
+        echo "2. Add strings manually"
+        echo "3. Add strings from a file"
+        echo "4. Finish"
+        read -rp $'\e[93;1mChoice [1-4]: \e[0m' choice
+
+        case "$choice" in
+            1)
+                for entry in "${default_strings[@]}"; do
+                    trimmed=${entry//$'\r'/}
+                    trimmed="${trimmed#${trimmed%%[![:space:]]*}}"
+                    trimmed="${trimmed%${trimmed##*[![:space:]]}}"
+                    if [[ -n $trimmed && -z ${seen_strings[$trimmed]+x} ]]; then
+                        collected_strings+=("$trimmed")
+                        seen_strings[$trimmed]=1
+                    fi
+                done
+                echo -e "\e[92mAdded default community strings.\e[0m"
+                ;;
+            2)
+                read -rp $'\e[93;1mEnter community strings (comma or space separated): \e[0m' cs_input
+                cs_input=${cs_input//,/ }
+                local -a manual_entries=()
+                if [[ -n $cs_input ]]; then
+                    read -ra manual_entries <<<"$cs_input"
+                fi
+                for entry in "${manual_entries[@]}"; do
+                    trimmed=${entry//$'\r'/}
+                    trimmed="${trimmed#${trimmed%%[![:space:]]*}}"
+                    trimmed="${trimmed%${trimmed##*[![:space:]]}}"
+                    if [[ -n $trimmed && -z ${seen_strings[$trimmed]+x} ]]; then
+                        collected_strings+=("$trimmed")
+                        seen_strings[$trimmed]=1
+                    fi
+                done
+                if [[ ${#manual_entries[@]} -gt 0 ]]; then
+                    echo -e "\e[92mAdded manual entries.\e[0m"
+                else
+                    echo -e "\e[93mNo manual entries detected.\e[0m"
+                fi
+                ;;
+            3)
+                read -rp $'\e[93;1mEnter file path: \e[0m' cs_file
+                if [[ ! -f "$cs_file" ]]; then
+                    echo -e "\e[91mCommunity string file not found: $cs_file\e[0m"
+                    continue
+                fi
+                while IFS= read -r line || [[ -n $line ]]; do
+                    line=${line//$'\r'/}
+                    line=${line//,/ }
+                    [[ -z $line ]] && continue
+                    local -a file_entries=()
+                    read -ra file_entries <<<"$line"
+                    for entry in "${file_entries[@]}"; do
+                        trimmed=${entry//$'\r'/}
+                        trimmed="${trimmed#${trimmed%%[![:space:]]*}}"
+                        trimmed="${trimmed%${trimmed##*[![:space:]]}}"
+                        if [[ -n $trimmed && -z ${seen_strings[$trimmed]+x} ]]; then
+                            collected_strings+=("$trimmed")
+                            seen_strings[$trimmed]=1
+                        fi
+                    done
+                done <"$cs_file"
+                echo -e "\e[92mLoaded community strings from file.\e[0m"
+                ;;
+            4)
+                if [[ ${#collected_strings[@]} -eq 0 ]]; then
+                    echo -e "\e[91mPlease add at least one community string before finishing.\e[0m"
+                    continue
+                fi
+                break
+                ;;
+            *)
+                echo -e "\e[91mInvalid choice. Please select option 1-4.\e[0m"
+                ;;
+        esac
+
+        if [[ ${#collected_strings[@]} -gt 0 ]]; then
+            echo -e "\e[94mCurrent community strings (${#collected_strings[@]}):\e[0m"
+            for entry in "${collected_strings[@]}"; do
+                echo "  - $entry"
+            done
+        fi
+    done
+
+    community_file=$(mktemp)
+    printf "%s\n" "${collected_strings[@]}" >"$community_file"
+    echo -e "\e[94mUsing ${#collected_strings[@]} community strings for all scans.\e[0m"
+    trap 'rm -f "$community_file"' EXIT
+}
+
+get_community_strings
+
 # Function to print a progress bar in light green color
 print_progress() {
-    local current=$1 # Arguments: current progress, total, current subnet/IP
+    local current=$1 # Arguments: current progress, total, current subnet/IP, entry type
     local total=$2
     local subnet_ip=$3
+    local entry_type=$4
     local progress=$((current * 100 / total))
     local completed=$((progress / 2))
     local remaining=$((50 - completed))
     local light_green="\e[92m"
     local reset_color="\e[0m"
-    printf "\rProgress: ${light_green}[%s%s] %d%%${reset_color} (Scanning %s, %s %d of %d)" "$(printf "%0.s#" $(seq 1 $completed))" "$(printf "%0.s-" $(seq 1 $remaining))" "$progress" "$subnet_ip" "$entry_type" "$current" "$total"
+    local completed_bar=""
+    local remaining_bar=""
+    if ((completed > 0)); then
+        completed_bar=$(printf "%0.s#" $(seq 1 $completed))
+    fi
+    if ((remaining > 0)); then
+        remaining_bar=$(printf "%0.s-" $(seq 1 $remaining))
+    fi
+    printf "\rProgress: ${light_green}[%s%s] %d%%${reset_color} (Scanning %s, %s %d of %d)" "$completed_bar" "$remaining_bar" "$progress" "$subnet_ip" "$entry_type" "$current" "$total"
 }
 
 # Define your subnets and IP addresses
@@ -45,58 +156,57 @@ validate_subnets_ip() {
         echo $(((a << 24) + (b << 16) + (c << 8) + d))
     }
 
-    # Function to convert integer to IP
-    int2ip() {
-        local ui32=$1
-        shift
-        local ip n
-        for n in 1 2 3 4; do
-            ip=$((ui32 & 0xff))${ip:+.}$ip
-            ui32=$((ui32 >> 8))
-        done
-        echo "$ip"
+    cidr_contains_ip() {
+        local cidr=$1
+        local ip=$2
+        local network mask
+        IFS=/ read -r network mask <<<"$cidr"
+        local network_int=$(ip2int "$network")
+        local ip_int=$(ip2int "$ip")
+        local mask_int
+        if ((mask == 0)); then
+            mask_int=0
+        else
+            mask_int=$(( (0xFFFFFFFF << (32 - mask)) & 0xFFFFFFFF ))
+        fi
+        [[ $((network_int & mask_int)) -eq $((ip_int & mask_int)) ]]
     }
 
-    # Function to expand subnet to IPs
-    expand_subnet() {
-        local ip mask
-        IFS=/ read -r ip mask <<<"$1"
-        local ip_dec=$(ip2int "$ip")
-        local range_size=$((2 ** (32 - mask)))
-        local i
-        for ((i = 0; i < range_size; i++)); do
-            echo "$(int2ip $((ip_dec + i)))"
-        done
-    }
+    if ((${#subnets[@]})); then
+        mapfile -t subnets < <(printf '%s\n' "${subnets[@]}" | awk 'NF' | sort -u)
+    else
+        subnets=()
+    fi
 
-    # Sort the subnets array from low to high
-    sorted_subnets=($(printf '%s\n' "${subnets[@]}" | sort))
+    if ((${#ip_addresses[@]})); then
+        mapfile -t ip_addresses < <(printf '%s\n' "${ip_addresses[@]}" | awk 'NF' | sort -u)
+    else
+        ip_addresses=()
+    fi
 
-    # Sort the IPs array from low to high
-    sorted_ips=($(printf '%s\n' "${ip_addresses[@]}" | sort))
-
-    # Echo the sorted subnets that will be scanned
     echo -e "\e[94mSubnets:\e[0m"
-    for subnet in "${sorted_subnets[@]}"; do
+    for subnet in "${subnets[@]}"; do
         echo "$subnet"
     done
 
-   # Echo the sorted IPs that will be scanned
     echo -e "\e[94mIP Addresses:\e[0m"
-    for ip in "${sorted_ips[@]}"; do
-        # Check if the IP is in any of the subnets
+    local -a filtered_ips=()
+    for ip in "${ip_addresses[@]}"; do
         local is_duplicate=false
-        for subnet in "${sorted_subnets[@]}"; do
-            if [[ $(expand_subnet "$subnet") =~ (^|[[:space:]])"$ip"($|[[:space:]]) ]]; then
+        for subnet in "${subnets[@]}"; do
+            if cidr_contains_ip "$subnet" "$ip"; then
                 echo "$ip - Duplicate entry. Scanner will skip. Subnet: $subnet"
                 is_duplicate=true
                 break
             fi
         done
-        if [ "$is_duplicate" = false ] ; then
+        if [[ $is_duplicate == false ]]; then
             echo "$ip"
+            filtered_ips+=("$ip")
         fi
     done
+
+    ip_addresses=("${filtered_ips[@]}")
 }
 
 # Ask the user to enter subnets and IP addresses manually or in a file containing the subnets/IPs
@@ -235,11 +345,6 @@ while true; do
     fi
 done
 
-# Sort the subnets and IP addresses
-IFS=$'\n' subnets=($(sort <<<"${subnets[*]}"))
-IFS=$'\n' ip_addresses=($(sort <<<"${ip_addresses[*]}"))
-unset IFS
-
 # Total number of subnets and IP addresses
 total_subnets=${#subnets[@]}
 total_ip_addresses=${#ip_addresses[@]}
@@ -277,28 +382,28 @@ fi
 echo "SNMPAT started at $now by user $current_user." >"$log_file"
 
 # Scan each subnet/IP one by one
-for i in "${!subnets[@]}" "${!ip_addresses[@]}"; do
-    if [[ $i -lt ${#subnets[@]} ]]; then
-        print_progress "$((i + 1))" "$total" "${subnets[$i]}" # Print progress bar for subnets
-    else
-        print_progress "$((i + 1))" "$total" "${ip_addresses[$i - ${#subnets[@]}]}" # Print progress bar for IP addresses
-    fi
-
-    if [[ $i -lt ${#subnets[@]} ]]; then
-        if ! onesixtyone -c <(echo -e "public\ncommunity\ndefault\nadmin\nprivate\npublic\nmanager\ncisco\nsnmp\nnetwork\nmonitor\nagent\ntrap\nread\nwrite") -i <(echo "${subnets[$i]}") >>"$log_file"; then
-            echo "Error occurred while scanning subnet: ${subnets[$i]}"
-        fi
-    else
-        if ! onesixtyone -c <(echo -e "public\ncommunity\ndefault\nadmin\nprivate\npublic\nmanager\ncisco\nsnmp\nnetwork\nmonitor\nagent\ntrap\nread\nwrite") -i <(echo "${ip_addresses[$i - ${#subnets[@]}]}") >>"$log_file"; then
-            echo "Error occurred while scanning IP address: ${ip_addresses[$i - ${#subnets[@]}]}"
-        fi
+current_index=0
+for subnet in "${subnets[@]}"; do
+    ((++current_index))
+    print_progress "$current_index" "$total" "$subnet" "Subnet"
+    if ! onesixtyone -c "$community_file" -i <(echo "$subnet") >>"$log_file"; then
+        echo "Error occurred while scanning subnet: $subnet"
     fi
 done
+
+for ip in "${ip_addresses[@]}"; do
+    ((++current_index))
+    print_progress "$current_index" "$total" "$ip" "IP"
+    if ! onesixtyone -c "$community_file" -i <(echo "$ip") >>"$log_file"; then
+        echo "Error occurred while scanning IP address: $ip"
+    fi
+done
+echo ""
 
 # Perform DNS lookup on each host and prepend hostname to each line
 sed -i '/Error in sendto: Permission denied/d' $log_file # Remove the "Error in sendto: Permission denied" line from the log file
 sed -i '/Scanning/d' $log_file                           # Remove the "Scanning" line from the log file
-awk 'NR>3 {print $1}' $log_file | sort -u | tail -n +4 | uniq | while read -r ip; do
+tail -n +5 "$log_file" | awk '{print $1}' | sort -u | while read -r ip; do
     if ! hostname=$(dig +short -x "$ip"); then
         echo "dig lookup failed for IP: $ip" >&2
         continue

--- a/SNMPAT.sh
+++ b/SNMPAT.sh
@@ -75,7 +75,7 @@ get_community_strings() {
             2)
                 read -rp $'\e[93;1mEnter community strings (comma or space separated): \e[0m' cs_input
                 cs_input=${cs_input//,/ }
-                manual_entries=()
+                local -a manual_entries=()
                 if [[ -n $cs_input ]]; then
                     read -ra manual_entries <<<"$cs_input"
                 fi
@@ -102,7 +102,7 @@ get_community_strings() {
                     line=$(trim_entry "$line")
                     line=${line//,/ }
                     [[ -z $line ]] && continue
-                    file_entries=()
+                    local -a file_entries=()
                     read -ra file_entries <<<"$line"
                     for entry in "${file_entries[@]}"; do
                         trimmed=$(trim_entry "$entry")
@@ -164,7 +164,7 @@ print_progress() {
 subnets=()
 ip_addresses=()
 
-validate_subnets_ip() {
+summarize_targets() {
     ip2int() {
         local a b c d
         IFS=. read -r a b c d <<<"$1"
@@ -198,17 +198,17 @@ validate_subnets_ip() {
         fi
     }
 
-    if ((${#subnets[@]})); then
-        mapfile -t subnets < <(printf '%s\n' "${subnets[@]}" | awk 'NF' | sort -u)
-    else
-        subnets=()
-    fi
+    dedupe_array() {
+        local -n input_ref=$1
+        if ((${#input_ref[@]})); then
+            mapfile -t input_ref < <(printf '%s\n' "${input_ref[@]}" | awk 'NF' | sort -u)
+        else
+            input_ref=()
+        fi
+    }
 
-    if ((${#ip_addresses[@]})); then
-        mapfile -t ip_addresses < <(printf '%s\n' "${ip_addresses[@]}" | awk 'NF' | sort -u)
-    else
-        ip_addresses=()
-    fi
+    dedupe_array subnets
+    dedupe_array ip_addresses
 
     echo -e "\e[94mSubnets:\e[0m"
     if ((${#subnets[@]} == 0)); then
@@ -240,6 +240,35 @@ validate_subnets_ip() {
     done
 
     ip_addresses=("${filtered_ips[@]}")
+}
+
+print_current_entries() {
+    echo "Current list of entries:"
+    if ((${#subnets[@]} == 0 && ${#ip_addresses[@]} == 0)); then
+        echo "  (none)"
+    else
+        for subnet in "${subnets[@]}"; do
+            [[ -n $subnet ]] && echo "  $subnet"
+        done
+        for ip in "${ip_addresses[@]}"; do
+            [[ -n $ip ]] && echo "  $ip"
+        done
+    fi
+}
+
+load_targets_from_file() {
+    local file_path=$1
+    local line
+    while IFS= read -r line || [[ -n $line ]]; do
+        line=$(trim_entry "$line")
+        line=${line//,/ }
+        [[ -z $line ]] && continue
+        local -a entries=()
+        read -ra entries <<<"$line"
+        for entry in "${entries[@]}"; do
+            add_target_entry "$entry"
+        done
+    done <"$file_path"
 }
 
 contains_entry() {
@@ -277,11 +306,8 @@ get_community_strings
 while true; do
     read -p $'\e[93;1mEnter subnet/IP or file: \e[0m' input
     if [[ $input == "done" ]]; then
-        echo "Current list of entries:"
-        for subnet_ip in "${subnets[@]}" "${ip_addresses[@]}"; do
-            [[ -n $subnet_ip ]] && echo "$subnet_ip"
-        done
-        validate_subnets_ip
+        print_current_entries
+        summarize_targets
         if [[ ${#subnets[@]} -eq 0 && ${#ip_addresses[@]} -eq 0 ]]; then
             echo "Please re-enter the subnets/IPs."
             subnets=()
@@ -291,21 +317,9 @@ while true; do
         break
     elif [[ $input == *.txt || $input == *.csv ]]; then
         if [[ -f $input ]]; then
-            while IFS= read -r line; do
-                line=$(trim_entry "$line")
-                line=${line//,/ }
-                [[ -z $line ]] && continue
-                entries=()
-                read -ra entries <<<"$line"
-                for entry in "${entries[@]}"; do
-                    add_target_entry "$entry"
-                done
-            done <"$input"
-            echo "Current list of entries:"
-            for subnet_ip in "${subnets[@]}" "${ip_addresses[@]}"; do
-                [[ -n $subnet_ip ]] && echo "$subnet_ip"
-            done
-            validate_subnets_ip
+            load_targets_from_file "$input"
+            print_current_entries
+            summarize_targets
             if [[ ${#subnets[@]} -eq 0 && ${#ip_addresses[@]} -eq 0 ]]; then
                 echo "Please re-enter the subnets/IPs."
                 subnets=()
@@ -326,16 +340,7 @@ while true; do
             [[ -z $token ]] && continue
             if [[ $token == *.txt || $token == *.csv ]]; then
                 if [[ -f $token ]]; then
-                    while IFS= read -r line; do
-                        line=$(trim_entry "$line")
-                        line=${line//,/ }
-                        [[ -z $line ]] && continue
-                        file_entries=()
-                        read -ra file_entries <<<"$line"
-                        for entry in "${file_entries[@]}"; do
-                            add_target_entry "$entry"
-                        done
-                    done <"$token"
+                    load_targets_from_file "$token"
                 else
                     echo "File not found: $token"
                 fi
@@ -343,16 +348,13 @@ while true; do
                 add_target_entry "$token"
             fi
         done
-        echo "Current list of entries:"
-        for subnet_ip in "${subnets[@]}" "${ip_addresses[@]}"; do
-            [[ -n $subnet_ip ]] && echo "$subnet_ip"
-        done
+        print_current_entries
         echo "" # Newline for clean output
         read -p $'\e[93;1mDo you want to add any more subnets/IPs? (y/n): \e[0m' add_more
         case $add_more in
         [Yy]*) continue ;;
         [Nn]*)
-            validate_subnets_ip
+            summarize_targets
             if [[ ${#subnets[@]} -eq 0 && ${#ip_addresses[@]} -eq 0 ]]; then
                 echo "Please re-enter the subnets/IPs."
                 subnets=()

--- a/SNMPAT.sh
+++ b/SNMPAT.sh
@@ -19,6 +19,33 @@ check_dependencies() {
 
 check_dependencies
 
+trim_entry() {
+    local entry=${1//$'\r'/}
+    entry="${entry#${entry%%[![:space:]]*}}"
+    entry="${entry%${entry##*[![:space:]]}}"
+    printf '%s' "$entry"
+}
+
+is_valid_ipv4() {
+    local candidate=$1
+    local IFS=.
+    read -r o1 o2 o3 o4 <<<"$candidate" || return 1
+    for octet in "$o1" "$o2" "$o3" "$o4"; do
+        [[ $octet =~ ^[0-9]+$ ]] || return 1
+        ((octet >= 0 && octet <= 255)) || return 1
+    done
+    return 0
+}
+
+is_valid_cidr() {
+    local candidate=$1
+    local network mask
+    IFS=/ read -r network mask <<<"$candidate" || return 1
+    [[ -n ${mask:-} && $mask =~ ^[0-9]+$ ]] || return 1
+    ((mask >= 0 && mask <= 32)) || return 1
+    is_valid_ipv4 "$network"
+}
+
 # Prompt user for SNMP community strings and store them in a temporary file
 get_community_strings() {
     local default_strings=("public" "community" "default" "admin" "private" "manager" "cisco" "snmp" "network" "monitor" "agent" "trap" "read" "write")
@@ -37,9 +64,7 @@ get_community_strings() {
         case "$choice" in
             1)
                 for entry in "${default_strings[@]}"; do
-                    trimmed=${entry//$'\r'/}
-                    trimmed="${trimmed#${trimmed%%[![:space:]]*}}"
-                    trimmed="${trimmed%${trimmed##*[![:space:]]}}"
+                    trimmed=$(trim_entry "$entry")
                     if [[ -n $trimmed && -z ${seen_strings[$trimmed]+x} ]]; then
                         collected_strings+=("$trimmed")
                         seen_strings[$trimmed]=1
@@ -50,14 +75,12 @@ get_community_strings() {
             2)
                 read -rp $'\e[93;1mEnter community strings (comma or space separated): \e[0m' cs_input
                 cs_input=${cs_input//,/ }
-                local -a manual_entries=()
+                manual_entries=()
                 if [[ -n $cs_input ]]; then
                     read -ra manual_entries <<<"$cs_input"
                 fi
                 for entry in "${manual_entries[@]}"; do
-                    trimmed=${entry//$'\r'/}
-                    trimmed="${trimmed#${trimmed%%[![:space:]]*}}"
-                    trimmed="${trimmed%${trimmed##*[![:space:]]}}"
+                    trimmed=$(trim_entry "$entry")
                     if [[ -n $trimmed && -z ${seen_strings[$trimmed]+x} ]]; then
                         collected_strings+=("$trimmed")
                         seen_strings[$trimmed]=1
@@ -76,15 +99,13 @@ get_community_strings() {
                     continue
                 fi
                 while IFS= read -r line || [[ -n $line ]]; do
-                    line=${line//$'\r'/}
+                    line=$(trim_entry "$line")
                     line=${line//,/ }
                     [[ -z $line ]] && continue
-                    local -a file_entries=()
+                    file_entries=()
                     read -ra file_entries <<<"$line"
                     for entry in "${file_entries[@]}"; do
-                        trimmed=${entry//$'\r'/}
-                        trimmed="${trimmed#${trimmed%%[![:space:]]*}}"
-                        trimmed="${trimmed%${trimmed##*[![:space:]]}}"
+                        trimmed=$(trim_entry "$entry")
                         if [[ -n $trimmed && -z ${seen_strings[$trimmed]+x} ]]; then
                             collected_strings+=("$trimmed")
                             seen_strings[$trimmed]=1
@@ -119,11 +140,8 @@ get_community_strings() {
     trap 'rm -f "$community_file"' EXIT
 }
 
-get_community_strings
-
-# Function to print a progress bar in light green color
 print_progress() {
-    local current=$1 # Arguments: current progress, total, current subnet/IP, entry type
+    local current=$1
     local total=$2
     local subnet_ip=$3
     local entry_type=$4
@@ -143,13 +161,10 @@ print_progress() {
     printf "\rProgress: ${light_green}[%s%s] %d%%${reset_color} (Scanning %s, %s %d of %d)" "$completed_bar" "$remaining_bar" "$progress" "$subnet_ip" "$entry_type" "$current" "$total"
 }
 
-# Define your subnets and IP addresses
 subnets=()
 ip_addresses=()
 
-# Function to validate subnets and IP addresses
 validate_subnets_ip() {
-    # Function to convert IP to integer
     ip2int() {
         local a b c d
         IFS=. read -r a b c d <<<"$1"
@@ -167,9 +182,20 @@ validate_subnets_ip() {
         if ((mask == 0)); then
             mask_int=0
         else
-            mask_int=$(( (0xFFFFFFFF << (32 - mask)) & 0xFFFFFFFF ))
+            mask_int=$(((0xFFFFFFFF << (32 - mask)) & 0xFFFFFFFF))
         fi
         [[ $((network_int & mask_int)) -eq $((ip_int & mask_int)) ]]
+    }
+
+    subnet_host_count() {
+        local cidr=$1
+        local _network mask
+        IFS=/ read -r _network mask <<<"$cidr"
+        if ((mask == 32)); then
+            echo 1
+        else
+            echo $((2 ** (32 - mask)))
+        fi
     }
 
     if ((${#subnets[@]})); then
@@ -185,23 +211,30 @@ validate_subnets_ip() {
     fi
 
     echo -e "\e[94mSubnets:\e[0m"
-    for subnet in "${subnets[@]}"; do
-        echo "$subnet"
-    done
+    if ((${#subnets[@]} == 0)); then
+        echo "  (none)"
+    else
+        for subnet in "${subnets[@]}"; do
+            printf '  %s (covers %s addresses)\n' "$subnet" "$(subnet_host_count "$subnet")"
+        done
+    fi
 
     echo -e "\e[94mIP Addresses:\e[0m"
     local -a filtered_ips=()
+    if ((${#ip_addresses[@]} == 0)); then
+        echo "  (none)"
+    fi
     for ip in "${ip_addresses[@]}"; do
         local is_duplicate=false
         for subnet in "${subnets[@]}"; do
             if cidr_contains_ip "$subnet" "$ip"; then
-                echo "$ip - Duplicate entry. Scanner will skip. Subnet: $subnet"
+                echo "  $ip - Duplicate entry. Scanner will skip. Subnet: $subnet"
                 is_duplicate=true
                 break
             fi
         done
         if [[ $is_duplicate == false ]]; then
-            echo "$ip"
+            echo "  $ip"
             filtered_ips+=("$ip")
         fi
     done
@@ -209,20 +242,47 @@ validate_subnets_ip() {
     ip_addresses=("${filtered_ips[@]}")
 }
 
-# Ask the user to enter subnets and IP addresses manually or in a file containing the subnets/IPs
-echo -e "\e[93mPlease enter the addresses you want to scan:\e[0m"
-echo "1. Subnet in CIDR format (e.g. 192.168.0.0/24, 10.0.0.0/8)"
-echo "2. Individual IP Addresses (e.g. 192.168.0.1, 10.0.0.1)"
-echo "3. .txt or .csv file (e.g. subnets.txt, subnets.csv)"
-echo -e "\e[94;1mEnter each value as a comma-separated list or as individual lines:\e[0m"
+contains_entry() {
+    local needle=$1
+    shift || return 1
+    local item
+    for item in "$@"; do
+        [[ $item == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+add_target_entry() {
+    local entry=$(trim_entry "$1")
+    [[ -z $entry ]] && return 0
+    if is_valid_cidr "$entry"; then
+        if contains_entry "$entry" "${subnets[@]}"; then
+            echo "Duplicate subnet entry: $entry"
+        else
+            subnets+=("$entry")
+        fi
+    elif is_valid_ipv4 "$entry"; then
+        if contains_entry "$entry" "${ip_addresses[@]}"; then
+            echo "Duplicate IP address entry: $entry"
+        else
+            ip_addresses+=("$entry")
+        fi
+    else
+        echo "Invalid subnet/IP format: $entry"
+    fi
+}
+
+get_community_strings
+
 while true; do
     read -p $'\e[93;1mEnter subnet/IP or file: \e[0m' input
     if [[ $input == "done" ]]; then
         echo "Current list of entries:"
         for subnet_ip in "${subnets[@]}" "${ip_addresses[@]}"; do
-            echo "$subnet_ip"
+            [[ -n $subnet_ip ]] && echo "$subnet_ip"
         done
-        if ! validate_subnets_ip; then
+        validate_subnets_ip
+        if [[ ${#subnets[@]} -eq 0 && ${#ip_addresses[@]} -eq 0 ]]; then
             echo "Please re-enter the subnets/IPs."
             subnets=()
             ip_addresses=()
@@ -232,27 +292,21 @@ while true; do
     elif [[ $input == *.txt || $input == *.csv ]]; then
         if [[ -f $input ]]; then
             while IFS= read -r line; do
-                if [[ $line =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]]; then # Validate subnet format
-                    if [[ " ${subnets[@]} " =~ " $line " ]]; then
-                        echo "Duplicate subnet entry: $line"
-                    else
-                        subnets+=("$line")
-                    fi
-                elif [[ $line =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then # Validate IP address format
-                    if [[ " ${ip_addresses[@]} " =~ " $line " ]]; then
-                        echo "Duplicate IP address entry: $line"
-                    else
-                        ip_addresses+=("$line")
-                    fi
-                else
-                    echo "Invalid subnet/IP format in file: $line"
-                fi
+                line=$(trim_entry "$line")
+                line=${line//,/ }
+                [[ -z $line ]] && continue
+                entries=()
+                read -ra entries <<<"$line"
+                for entry in "${entries[@]}"; do
+                    add_target_entry "$entry"
+                done
             done <"$input"
             echo "Current list of entries:"
             for subnet_ip in "${subnets[@]}" "${ip_addresses[@]}"; do
-                echo "$subnet_ip"
+                [[ -n $subnet_ip ]] && echo "$subnet_ip"
             done
-            if ! validate_subnets_ip; then
+            validate_subnets_ip
+            if [[ ${#subnets[@]} -eq 0 && ${#ip_addresses[@]} -eq 0 ]]; then
                 echo "Please re-enter the subnets/IPs."
                 subnets=()
                 ip_addresses=()
@@ -263,76 +317,43 @@ while true; do
             echo "File not found. Please try again."
         fi
     else
-        IFS=',' read -ra subnet_ip_list <<<"$input" # Validate subnet/IP format
-        for subnet_ip in "${subnet_ip_list[@]}"; do
-            if [[ $subnet_ip =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]]; then
-                if [[ " ${subnets[@]} " =~ " $subnet_ip " ]]; then
-                    echo "Duplicate subnet entry: $subnet_ip"
+        input=$(trim_entry "$input")
+        input=${input//,/ }
+        tokens=()
+        read -ra tokens <<<"$input"
+        for token in "${tokens[@]}"; do
+            token=$(trim_entry "$token")
+            [[ -z $token ]] && continue
+            if [[ $token == *.txt || $token == *.csv ]]; then
+                if [[ -f $token ]]; then
+                    while IFS= read -r line; do
+                        line=$(trim_entry "$line")
+                        line=${line//,/ }
+                        [[ -z $line ]] && continue
+                        file_entries=()
+                        read -ra file_entries <<<"$line"
+                        for entry in "${file_entries[@]}"; do
+                            add_target_entry "$entry"
+                        done
+                    done <"$token"
                 else
-                    subnets+=("$subnet_ip")
-                fi
-            elif [[ $subnet_ip =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
-                if [[ " ${ip_addresses[@]} " =~ " $subnet_ip " ]]; then
-                    echo "Duplicate IP address entry: $subnet_ip"
-                else
-                    ip_addresses+=("$subnet_ip")
+                    echo "File not found: $token"
                 fi
             else
-                # Check if the input contains a file and individual subnet/IP entry on the same line
-                IFS=' ' read -ra entries <<<"$subnet_ip"
-                for entry in "${entries[@]}"; do
-                    if [[ $entry == *.txt || $entry == *.csv ]]; then
-                        if [[ -f $entry ]]; then
-                            while IFS= read -r line; do
-                                if [[ $line =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]]; then # Validate subnet format
-                                    if [[ " ${subnets[@]} " =~ " $line " ]]; then
-                                        echo "Duplicate subnet entry: $line"
-                                    else
-                                        subnets+=("$line")
-                                    fi
-                                elif [[ $line =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then # Validate IP address format
-                                    if [[ " ${ip_addresses[@]} " =~ " $line " ]]; then
-                                        echo "Duplicate IP address entry: $line"
-                                    else
-                                        ip_addresses+=("$line")
-                                    fi
-                                else
-                                    echo "Invalid subnet/IP format in file: $line"
-                                fi
-                            done <"$entry"
-                        else
-                            echo "File not found: $entry"
-                        fi
-                    else
-                        if [[ $entry =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$ ]]; then
-                            if [[ " ${subnets[@]} " =~ " $entry " ]]; then
-                                echo "Duplicate subnet entry: $entry"
-                            else
-                                subnets+=("$entry")
-                            fi
-                        elif [[ $entry =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
-                            if [[ " ${ip_addresses[@]} " =~ " $entry " ]]; then
-                                echo "Duplicate IP address entry: $entry"
-                            else
-                                ip_addresses+=("$entry")
-                            fi
-                        else
-                            echo "Invalid subnet/IP format: $entry"
-                        fi
-                    fi
-                done
+                add_target_entry "$token"
             fi
         done
         echo "Current list of entries:"
         for subnet_ip in "${subnets[@]}" "${ip_addresses[@]}"; do
-            echo "$subnet_ip"
+            [[ -n $subnet_ip ]] && echo "$subnet_ip"
         done
         echo "" # Newline for clean output
         read -p $'\e[93;1mDo you want to add any more subnets/IPs? (y/n): \e[0m' add_more
         case $add_more in
         [Yy]*) continue ;;
         [Nn]*)
-            if ! validate_subnets_ip; then
+            validate_subnets_ip
+            if [[ ${#subnets[@]} -eq 0 && ${#ip_addresses[@]} -eq 0 ]]; then
                 echo "Please re-enter the subnets/IPs."
                 subnets=()
                 ip_addresses=()

--- a/tests/mocks/dig
+++ b/tests/mocks/dig
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -eq 3 && $1 == '+short' && $2 == '-x' ]]; then
+    ip=$3
+    echo "mock-host-${ip//./-}"
+    exit 0
+fi
+
+echo "dig stub: unsupported invocation $*" >&2
+exit 1

--- a/tests/mocks/onesixtyone
+++ b/tests/mocks/onesixtyone
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+community_file=""
+input_file=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c)
+            community_file="$2"
+            shift 2
+            ;;
+        -i)
+            input_file="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [[ -z ${community_file:-} || -z ${input_file:-} ]]; then
+    echo "usage: onesixtyone -c <community_file> -i <input_file>" >&2
+    exit 1
+fi
+
+mapfile -t ips <"$input_file"
+mapfile -t communities <"$community_file"
+
+for ip in "${ips[@]}"; do
+    [[ -z $ip ]] && continue
+    echo "Scanning $ip..."
+    for community in "${communities[@]}"; do
+        [[ -z $community ]] && continue
+        echo "$ip [$community] mock-response"
+    done
+done

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export PATH="$REPO_ROOT/tests/mocks:$PATH"
+export HOME="$REPO_ROOT/tests/tmp_home"
+mkdir -p "$HOME"
+
+test_output="$HOME/test_run.log"
+rm -f "$test_output"
+
+printf '1\n4\n192.168.1.1\nn\nno\n' | bash "$REPO_ROOT/SNMPAT.sh" >"$test_output"
+
+if grep -q "SNMPAT completed" "$test_output"; then
+    echo "SNMPAT smoke test passed"
+    rm -f "$test_output" "$HOME"/SNMPAT_log_*.log
+else
+    echo "SNMPAT smoke test failed: completion message missing" >&2
+    exit 1
+fi

--- a/tests/tmp_home/.gitignore
+++ b/tests/tmp_home/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- fix the target validation and scan loops so subnets/IPs are sorted without expansion, duplicates are removed, and progress output no longer exits early
- add a smoke-test harness with mocked `onesixtyone`/`dig` binaries to exercise the interactive workflow automatically
- document the new smoke test in the README and correct the script name in the usage instructions

## Testing
- `tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895463d1308832a9defd05fb2512ec6